### PR TITLE
setuptools tried to import main module before it was installed

### DIFF
--- a/phishnetpy/__init__.py
+++ b/phishnetpy/__init__.py
@@ -8,4 +8,12 @@ from phishnetpy import exceptions
 import pkg_resources
 
 # the version is stored here upon initial installation
-__version__ = pkg_resources.require("phishnetpy")[0].version
+try:
+    __version__ = pkg_resources.require("phishnetpy")[0].version
+except pkg_resources.DistributionNotFound:
+    # this will happen during local development
+    # we should move the string to a TBD singular location
+    __version__ = '0.2.4'
+except:
+    print('could not determine version!')
+    raise

--- a/phishnetpy/__init__.py
+++ b/phishnetpy/__init__.py
@@ -4,7 +4,8 @@ from phishnetpy.phishnet_api import PhishNetAPI
 from phishnetpy import decorators
 from phishnetpy import exceptions
 
-VERSION = '0.2.3'
+# this package is part of setuptools
+import pkg_resources
 
-__version__ = VERSION
-
+# the version is stored here upon initial installation
+__version__ = pkg_resources.require("phishnetpy")[0].version

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@ here = path.abspath(path.dirname(__file__))
 # with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
 #     long_description = f.read()
 
-from phishnetpy import VERSION
-
 setup(
 
     name='phishnetpy',
@@ -19,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version=VERSION,
+    version='0.2.4',
 
     description='Python client for the Phish.net API',
     # long_description=long_description,


### PR DESCRIPTION
Hey @jameserrico, this fixes the error below that I was getting when pip installing. See explanation [here](http://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package#answer-2073599). :)

```
Downloading/unpacking phishnetpy
  Downloading phishnetpy-0.2.3.tar.gz
  Running setup.py (path:/private/tmp/pip_build_root/phishnetpy/setup.py) egg_info for package phishnetpy
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/private/tmp/pip_build_root/phishnetpy/setup.py", line 13, in <module>
        from phishnetpy import VERSION
      File "phishnetpy/__init__.py", line 3, in <module>
        from phishnetpy.phishnet_api import PhishNetAPI
      File "phishnetpy/phishnet_api.py", line 4, in <module>
        import arrow
    ImportError: No module named arrow
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/private/tmp/pip_build_root/phishnetpy/setup.py", line 13, in <module>

    from phishnetpy import VERSION

  File "phishnetpy/__init__.py", line 3, in <module>

    from phishnetpy.phishnet_api import PhishNetAPI

  File "phishnetpy/phishnet_api.py", line 4, in <module>

    import arrow

ImportError: No module named arrow

```
